### PR TITLE
fix: work properly with updated extensions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         targetSdk 33
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 8
-        versionName "1.1.1"
+        versionCode 9
+        versionName "1.1.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/lagradost/ExtensionLoader.kt
+++ b/app/src/main/java/com/lagradost/ExtensionLoader.kt
@@ -53,7 +53,7 @@ class AnimeExtensionLoader() {
     private  val METADATA_HAS_README = "tachiyomi.animeextension.hasReadme"
     private  val METADATA_HAS_CHANGELOG = "tachiyomi.animeextension.hasChangelog"
      val LIB_VERSION_MIN = 12
-     val LIB_VERSION_MAX = 14
+     val LIB_VERSION_MAX = 15
 
     private  val PACKAGE_FLAGS =
         PackageManager.GET_CONFIGURATIONS or PackageManager.GET_SIGNATURES
@@ -156,8 +156,8 @@ class AnimeExtensionLoader() {
         }
 
         // Validate lib version
-        val libVersion = versionName.substringBeforeLast('.').toDouble()
-        if (libVersion < LIB_VERSION_MIN || libVersion > LIB_VERSION_MAX) {
+        val libVersion = versionName.substringBeforeLast('.').toDoubleOrNull()
+        if (libVersion == null || libVersion < LIB_VERSION_MIN || libVersion > LIB_VERSION_MAX) {
             logcat {
                 "Lib version is $libVersion, while only versions " +
                         "$LIB_VERSION_MIN to $LIB_VERSION_MAX are allowed"

--- a/app/src/main/java/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
@@ -65,16 +65,11 @@ fun Call.asObservable(): Observable<Response> {
 
 // Based on https://github.com/gildor/kotlin-coroutines-okhttp
 @OptIn(ExperimentalCoroutinesApi::class)
-suspend fun Call.await(): Response {
+private suspend fun Call.await(callStack: Array<StackTraceElement>): Response {
     return suspendCancellableCoroutine { continuation ->
-        enqueue(
+        val callback =
             object : Callback {
                 override fun onResponse(call: Call, response: Response) {
-                    if (!response.isSuccessful) {
-                        continuation.resumeWithException(HttpException(response.code))
-                        return
-                    }
-
                     continuation.resume(response) {
                         response.body.close()
                     }
@@ -83,10 +78,12 @@ suspend fun Call.await(): Response {
                 override fun onFailure(call: Call, e: IOException) {
                     // Don't bother with resuming the continuation if it is already cancelled.
                     if (continuation.isCancelled) return
-                    continuation.resumeWithException(e)
+                    val exception = IOException(e.message, e).apply { stackTrace = callStack }
+                    continuation.resumeWithException(exception)
                 }
-            },
-        )
+            }
+
+        enqueue(callback)
 
         continuation.invokeOnCancellation {
             try {
@@ -96,6 +93,24 @@ suspend fun Call.await(): Response {
             }
         }
     }
+}
+
+suspend fun Call.await(): Response {
+    val callStack = Exception().stackTrace.run { copyOfRange(1, size) }
+    return await(callStack)
+}
+
+/**
+ * @since extensions-lib 1.5
+ */
+suspend fun Call.awaitSuccess(): Response {
+    val callStack = Exception().stackTrace.run { copyOfRange(1, size) }
+    val response = await(callStack)
+    if (!response.isSuccessful) {
+        response.close()
+        throw HttpException(response.code).apply { stackTrace = callStack }
+    }
+    return response
 }
 
 fun Call.asObservableSuccess(): Observable<Response> {


### PR DESCRIPTION
This fixes the loadlinks failure in extensions that are using extlib-14 from aniyomi.
Quickjs dependency in build.gradle is needed in the main cloudstream app for some sources to appear.